### PR TITLE
chore: 📝 Ajout d'une image des contributeurs dans le README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,9 @@ Code d'un jeu plateformer en Python avec p5 dans le cadre d'un projet de NSI
 [Cahier des charges](./cdc.md)
 
 [Charte Graphique](./charte%20graphique.md)
+
+## Contributeurs
+
+<a href="https://github.com/Greensky-NSI/platformer-py/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=Greensky-NSI/platformer-py" />
+</a>


### PR DESCRIPTION
# Ajout d'une image des contributeurs

Le [README](https://github.com/Greensky-NSI/platformer-py/blob/master/README.md) est maintenant pourvu d'une image des contributeurs

## Changements

* Ajout d'une image depuis le site [**contrib.rocks**](https://contrib.rocks) ( https://github.com/Greensky-NSI/platformer-py/commit/bfce3d83639606dbcd26fc0b1c03b6587100dfe6 ) - @Greensky-gs 

# Contributeurs

@Greensky-gs 